### PR TITLE
Fix memory issues on Metacentrum

### DIFF
--- a/common/common.py
+++ b/common/common.py
@@ -5,6 +5,7 @@ from torchaudio.datasets import VoxCeleb1Identification
 
 DATASET_DIR = Path(os.getenv("KNN_DATASET_DIR", default="voxceleb1"))
 DATASET_DIR.mkdir(parents=True, exist_ok=True)
+SAMPLE_RATE = 16_000
 
 
 def download_voxceleb(split="train"):

--- a/evaluate.py
+++ b/evaluate.py
@@ -6,7 +6,7 @@ import torch
 
 from models import preprocess
 from models.ecapa import ECAPA_TDNN
-from common.common import DATASET_DIR
+from common.common import DATASET_DIR, SAMPLE_RATE
 
 from pathlib import Path
 from sklearn import metrics
@@ -31,7 +31,6 @@ DET_DIR = Path("experiments/det")
 DET_DIR.mkdir(parents=True, exist_ok=True)
 
 LOG_INTERVAL = 500
-EXPECTED_SAMPLE_RATE = 16_000
 
 
 def to_filename(string):
@@ -142,7 +141,7 @@ def evaluate_on_voxceleb1(
         scores = []
         labels = []
         for left, right, sr, t, _, _ in train_dataloader:
-            assert sr == EXPECTED_SAMPLE_RATE
+            assert sr == SAMPLE_RATE
             i += 1
 
             left_embedding = get_embeddings(left.to(device), model)

--- a/metacentrum/README.md
+++ b/metacentrum/README.md
@@ -3,6 +3,8 @@
 This directory contains scripts for executing workloads on Metacentrum. The documentation can be found
 [at this URL](https://docs.metacentrum.cz/). Before you start, create a Metacentrum account following the docs.
 
+As the next major improvement, it would be nice to update to latest version of pytorch (using the old approach).
+
 ## Environment setup
 
 ```shell

--- a/metacentrum/train_model_job
+++ b/metacentrum/train_model_job
@@ -12,7 +12,7 @@
 
 #PBS -N batch_job_knn
 #PBS -q gpu
-#PBS -l select=1:ncpus=2:ngpus=1:gpu_mem=20gb:mem=20gb:scratch_local=30gb
+#PBS -l select=1:ncpus=1:ngpus=1:gpu_mem=20gb:mem=20gb:scratch_local=30gb
 #PBS -j oe
 #PBS -m ae
 

--- a/train_ecapa.py
+++ b/train_ecapa.py
@@ -6,7 +6,7 @@ from torch.utils.data import default_collate
 from torchaudio.datasets import VoxCeleb1Identification
 from torch.utils.data import DataLoader
 
-from common.common import DATASET_DIR
+from common.common import DATASET_DIR, SAMPLE_RATE
 from models.ecapa import ECAPA_TDNN, Classifier
 from speechbrain.nnet.losses import LogSoftmaxWrapper, AdditiveAngularMargin
 
@@ -27,11 +27,15 @@ VIEW_STEP = int(os.getenv("KNN_VIEW_STEP", default=50))
 def collate_with_padding(batch):
     """
     Performs zero right padding and then calls `default_collate` function.
+
+    Also, trims all recordings to 5 seconds.
     """
-    max_length = max([(b[0].shape[1]) for b in batch])
+    # max_length = max([(b[0].shape[1]) for b in batch])
+    max_length = 5 * SAMPLE_RATE
     new_batch = []
     lengths = []
     for tensor, sr, speaker_id, filename in batch:
+        tensor = tensor[:max_length]
         tensor = torch.nn.functional.pad(tensor, (0, max_length - tensor.shape[1]))
         new_batch.append((tensor, sr, speaker_id, filename))
         lengths.append(tensor.shape[1] / max_length)

--- a/train_ecapa.py
+++ b/train_ecapa.py
@@ -124,7 +124,10 @@ if __name__ == "__main__":
                     f"Iteration {iteration}, average loss: {loss_acc / VIEW_STEP}, prediction accuracy "
                     f"{hits_acc / (VIEW_STEP * BATCH_SIZE)}"
                 )
-                print(f"Used GPU memory {torch.cuda.memory_allocated() / 1024 ** 3} GB")
+                print(
+                    f"Memory allocated: {torch.cuda.memory_allocated() / 1024 ** 3} GB, "
+                    f"memory reserved: {torch.cuda.memory_reserved() / 1024 ** 3} GB"
+                )
                 loss_acc = 0
                 hits_acc = 0
 

--- a/train_ecapa.py
+++ b/train_ecapa.py
@@ -80,7 +80,7 @@ if __name__ == "__main__":
     classify.train()
 
     optimizer = torch.optim.Adam(
-        list(model.parameters()) + list(classify.parameters()), lr=0.001, weight_decay=0.000002
+        [{"params": model.parameters()}, {"params": classify.parameters()}], lr=0.001, weight_decay=0.000002
     )
     if MODEL_IN_DIR is not None:
         optimizer.load_state_dict(

--- a/train_ecapa.py
+++ b/train_ecapa.py
@@ -111,16 +111,16 @@ if __name__ == "__main__":
             optimizer.zero_grad()
 
             outputs = model(x)
-            cls_out = classify(outputs)
-
+            cls_out = classify(outputs).squeeze(1)
             loss = criterion(cls_out, batch_labels)
             loss.backward()  # Compute gradients
             optimizer.step()
 
+            batch_labels = batch_labels.squeeze(1)
             # Compute stats
             loss_acc += loss.item()
-            _, pred_labels = torch.max(outputs, 2)
-            hits_acc += torch.sum(torch.eq(batch_labels, pred_labels)).item()
+            _, pred_labels = torch.max(cls_out, 1)
+            hits_acc += (pred_labels == batch_labels.squeeze()).sum().item()
 
             # Print stats
             if iteration % VIEW_STEP == 0:


### PR DESCRIPTION
This PR fixes all memory issues we had on Metacentrum by setting all data's length to 5 seconds by trimming and (already implemented) zero padding.